### PR TITLE
Add fix for payload item being None in aggregation.

### DIFF
--- a/src/rassumfrassum/frassum.py
+++ b/src/rassumfrassum/frassum.py
@@ -271,7 +271,11 @@ class LspLogic:
 
         elif method == 'textDocument/codeAction':
             res = reduce(
-                lambda acc, item: acc + cast(list, item.payload), items, []
+                lambda acc, item: acc + cast(list, item.payload)
+                if item.payload
+                else acc,
+                items,
+                [],
             )
 
         elif method == 'textDocument/completion':


### PR DESCRIPTION
Addresses: joaotavora/rassumfrassum#9

Still not sure how the `PayloadItem` could be `None` in context. 