### PR TITLE
relay server extension for supporting volar ls (vue + ts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ are very simple, and some are slightly more complex.
 
 * `vuetail`: for `vue-language-server` + `tailwindcss-language-server`
   (complex)
+
+* `emacsvue`: for `vue-language-server` with tsserver relay (complex)
   
 The "complex" presets use special hooks of the 'LspLogic' class to
 massage the exchanged messages.  The servers in question (usually the

--- a/src/rassumfrassum/frassum.py
+++ b/src/rassumfrassum/frassum.py
@@ -93,6 +93,8 @@ class LspLogic:
         self.commands_map: dict[str, Server] = {}
         # Track file watchers: registration_id -> (server, list of expanded glob patterns)
         self.file_watchers: dict[str, tuple[Server, list[str]]] = {}
+        # Relay handlers: match_method -> RelayHandler (set by rassum.py)
+        self.relay_handlers: dict = {}
 
     async def on_client_request(
         self, method: str, params: JSON, servers: list[Server]
@@ -109,6 +111,23 @@ class LspLogic:
             List of servers that should receive the request, or
             DirectResponse to send immediately without forwarding
         """
+        result = await self._route_request(method, params, servers)
+
+        # Include relay servers configured to handle this request method
+        if isinstance(result, list):
+            for handler in self.relay_handlers.values():
+                if (
+                    handler.spec.forward_requests
+                    and method in handler.spec.forward_requests
+                ):
+                    result.append(handler.server)
+
+        return result
+
+    async def _route_request(
+        self, method: str, params: JSON, servers: list[Server]
+    ) -> list[Server] | DirectResponse:
+        """Core routing logic for client requests."""
         # Check for data recovery from stash
         if method.endswith("resolve") and (
             stashed := self.stash.get(cast(int, params.get('data')))
@@ -137,6 +156,13 @@ class LspLogic:
             # Force UTF-16 encoding to avoid position mismatches (#8)
             if g := params['capabilities'].get('general'):
                 g['positionEncodings'] = ['utf-16']
+
+            # Merge initializationOptions from CLI/preset
+            if init_opts := getattr(self.opts, 'init_options', None):
+                params['initializationOptions'] = dmerge(
+                    params.get('initializationOptions') or {},
+                    init_opts,
+                )
 
             # In streaming mode, add diagnostic capability to client
             if self.opts.stream_diagnostics:
@@ -255,14 +281,26 @@ class LspLogic:
                 self.document_state[uri] = state
                 return state
 
+        async def forward_relay():
+            for handler in self.relay_handlers.values():
+                if (
+                    handler.spec.forward_notifications
+                    and method in handler.spec.forward_notifications
+                ):
+                    asyncio.create_task(
+                        self._forward_to_relay(handler, method, params)
+                    )
+
         if method == 'textDocument/didClose':
             reset_state(params["textDocument"]["uri"], None)
             await forward_all()
+            await forward_relay()
         elif method in ('textDocument/didOpen', 'textDocument/didChange'):
             uri = params["textDocument"]["uri"]
             v = params["textDocument"]["version"]
             state = reset_state(uri, v)
             await forward_all()
+            await forward_relay()
             # In streaming mode, pull diagnostics from pull-capable servers
             if self.opts.stream_diagnostics:
                 await self._pull_and_stream_diags(
@@ -280,8 +318,15 @@ class LspLogic:
                     ):
                         await self.notify_server(server, method, params)
                         break
+            await forward_relay()
         else:
             await forward_all()
+            await forward_relay()
+
+    async def _forward_to_relay(self, handler, method: str, params: JSON):
+        """Forward a notification to a relay server, waiting for init."""
+        await handler.initialized.wait()
+        await self.notify_server(handler.server, method, params)
 
     async def on_client_response(
         self,
@@ -331,6 +376,11 @@ class LspLogic:
         """
         Handle server notifications and forward to client.
         """
+        # Check relay handlers before normal forwarding
+        if handler := self.relay_handlers.get(method):
+            asyncio.create_task(handler.handle_notification(params, source))
+            return
+
         # Special handling for diagnostics
         if (
             method == 'textDocument/publishDiagnostics'
@@ -418,8 +468,6 @@ class LspLogic:
                 self._stash_data(action, server, doc_state)
                 if (command := action.get("command")) and (
                     command_name := command.get("command")
-                    if isinstance(command, dict)
-                    else command
                 ):
                     self.commands_map[command_name] = server
         elif (

--- a/src/rassumfrassum/main.py
+++ b/src/rassumfrassum/main.py
@@ -5,6 +5,7 @@ rassumfrassum - A simple LSP multiplexer that forwards JSONRPC messages.
 
 import argparse
 import asyncio
+import json
 import sys
 
 from . import __version__
@@ -23,36 +24,51 @@ from .util import (
 )
 
 
-def parse_server_commands(argv: list[str]) -> tuple[list[str], list[list[str]]]:
+def parse_server_commands(
+    argv: list[str],
+) -> tuple[list[str], list[list[str]], list[list[str]]]:
     """
-    Split argv on '--' separators.
-    Returns (rass_args, [server_command1, server_command2, ...])
+    Split argv on '--' and '---' separators.
+    Returns (rass_args, server_commands, relay_server_commands)
+
+    '--' separates regular server commands.
+    '---' separates relay server commands.
     """
-    if "--" not in argv:
-        return argv, []
+    if "--" not in argv and "---" not in argv:
+        return argv, [], []
 
-    # Find all '--' separator indices
-    separator_indices = [i for i, arg in enumerate(argv) if arg == "--"]
+    # Find first separator (either -- or ---)
+    first_sep = None
+    for i, arg in enumerate(argv):
+        if arg in ("--", "---"):
+            first_sep = i
+            break
 
-    # Everything before first '--' is rass options
-    rass_args = argv[: separator_indices[0]]
+    if first_sep is None:
+        return argv, [], []
 
-    # Split server commands
+    # Everything before first separator is rass options
+    rass_args = argv[:first_sep]
+
+    # Walk through remaining args, splitting on separators
     server_commands: list[list[str]] = []
-    for i, sep_idx in enumerate(separator_indices):
-        # Find start and end of this server command
-        start = sep_idx + 1
-        end = (
-            separator_indices[i + 1]
-            if i + 1 < len(separator_indices)
-            else len(argv)
-        )
+    relay_server_commands: list[list[str]] = []
+    current: list[str] = []
+    is_relay = False
 
-        server_cmd: list[str] = argv[start:end]
-        if server_cmd:  # Only add non-empty commands
-            server_commands.append(server_cmd)
+    for arg in argv[first_sep:]:
+        if arg in ("--", "---"):
+            if current:
+                (relay_server_commands if is_relay else server_commands).append(current)
+                current = []
+            is_relay = (arg == "---")
+        else:
+            current.append(arg)
 
-    return rass_args, server_commands
+    if current:
+        (relay_server_commands if is_relay else server_commands).append(current)
+
+    return rass_args, server_commands, relay_server_commands
 
 
 def main(argv=None) -> None:
@@ -63,8 +79,8 @@ def main(argv=None) -> None:
         import sys
         argv = sys.argv[1:]
 
-    # Parse multiple '--' separators for multiple servers
-    rass_args, server_commands = parse_server_commands(argv)
+    # Parse multiple '--' / '---' separators for servers and relay servers
+    rass_args, server_commands, relay_server_commands = parse_server_commands(argv)
 
     # Parse rass options with argparse
     parser = argparse.ArgumentParser(
@@ -121,6 +137,54 @@ def main(argv=None) -> None:
         metavar='N',
         help='Maximum log message length in bytes; 0 for unlimited (default: 4000).',
     )
+    parser.add_argument(
+        '--relay-match',
+        type=str,
+        metavar='METHOD',
+        help='Notification method to intercept from source servers for relay.',
+    )
+    parser.add_argument(
+        '--relay-send',
+        type=str,
+        metavar='METHOD',
+        help='Request method to send to relay server.',
+    )
+    parser.add_argument(
+        '--relay-respond',
+        type=str,
+        metavar='METHOD',
+        help='Notification method to send back to source server.',
+    )
+    parser.add_argument(
+        '--relay-command',
+        type=str,
+        metavar='CMD',
+        help='Command name for workspace/executeCommand relay.',
+    )
+    parser.add_argument(
+        '--relay-forward',
+        type=str,
+        metavar='METHODS',
+        help='Comma-separated notification methods to forward to relay servers (e.g. textDocument/didOpen,textDocument/didChange,textDocument/didClose).',
+    )
+    parser.add_argument(
+        '--relay-forward-requests',
+        type=str,
+        metavar='METHODS',
+        help='Comma-separated request methods to also route to relay servers (e.g. textDocument/definition).',
+    )
+    parser.add_argument(
+        '--init-options',
+        type=str,
+        metavar='JSON',
+        help='JSON object to merge into primary server initializationOptions.',
+    )
+    parser.add_argument(
+        '--relay-init-options',
+        type=str,
+        metavar='JSON',
+        help='JSON object to merge into relay server initializationOptions.',
+    )
     opts = parser.parse_args(rass_args)
 
     # Set log level based on argument
@@ -135,17 +199,54 @@ def main(argv=None) -> None:
     set_log_level(log_level_map[opts.log_level])
     set_max_log_length(opts.max_log_length)
 
+    # Parse JSON CLI options
+    cli_init_options = json.loads(opts.init_options) if opts.init_options else None
+    cli_relay_init_options = json.loads(opts.relay_init_options) if opts.relay_init_options else None
+
     # Load preset if specified
     preset_logic_class = None
+    relay_spec = None
+    preset_init_options = None
     if opts.preset:
-        preset_servers, preset_logic_class = load_preset(opts.preset)
+        preset_servers, preset_logic_class, preset_relay_servers, preset_relay_spec, preset_init_options = load_preset(opts.preset)
         server_commands = preset_servers + server_commands
+        relay_server_commands = preset_relay_servers + relay_server_commands
+        relay_spec = preset_relay_spec
 
         # Use preset logic class if --logic-class wasn't explicitly set
         if preset_logic_class and '--logic-class' not in rass_args:
             opts.logic_class = (
                 f"{preset_logic_class.__module__}.{preset_logic_class.__name__}"
             )
+
+    # Merge init_options: preset as base, CLI overrides on top
+    if preset_init_options or cli_init_options:
+        opts.init_options = {**(preset_init_options or {}), **(cli_init_options or {})}
+    else:
+        opts.init_options = None
+
+    # CLI relay args override anything from the preset
+    forward = opts.relay_forward.split(',') if opts.relay_forward else None
+    forward_reqs = opts.relay_forward_requests.split(',') if opts.relay_forward_requests else None
+    if opts.relay_match:
+        from .relay import RelaySpec
+        relay_spec = RelaySpec(
+            match_method=opts.relay_match,
+            send_method=opts.relay_send or 'workspace/executeCommand',
+            respond_method=opts.relay_respond or opts.relay_match.replace('/request', '/response'),
+            command=opts.relay_command,
+            forward_notifications=forward,
+            forward_requests=forward_reqs,
+            init_options=cli_relay_init_options,
+        )
+    else:
+        if forward and relay_spec:
+            relay_spec.forward_notifications = forward
+        if forward_reqs and relay_spec:
+            relay_spec.forward_requests = forward_reqs
+        # CLI --relay-init-options overrides preset relay_spec init_options
+        if cli_relay_init_options and relay_spec:
+            relay_spec.init_options = {**(relay_spec.init_options or {}), **cli_relay_init_options}
 
     if not server_commands:
         log(
@@ -157,7 +258,11 @@ def main(argv=None) -> None:
     assert opts.delay_ms >= 0, "--delay-ms must be non-negative"
 
     try:
-        asyncio.run(run_multiplexer(server_commands, opts))
+        asyncio.run(run_multiplexer(
+            server_commands, opts,
+            relay_server_commands=relay_server_commands,
+            relay_spec=relay_spec,
+        ))
     except KeyboardInterrupt:
         log("\nShutting down...")
     except Exception as e:

--- a/src/rassumfrassum/preset.py
+++ b/src/rassumfrassum/preset.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from .util import PresetResult
+from .util import PresetResult, ExtendedPresetResult
 
 
 def _get_config_dirs() -> list[Path]:
@@ -34,7 +34,7 @@ def _get_config_dirs() -> list[Path]:
     return dirs
 
 
-def load_preset(name_or_path: str) -> PresetResult:
+def load_preset(name_or_path: str) -> ExtendedPresetResult:
     """
     Load preset by name or file path.
 
@@ -44,6 +44,9 @@ def load_preset(name_or_path: str) -> PresetResult:
 
     Args:
         name_or_path: 'python' or './my_preset.py'
+
+    Returns:
+        (server_commands, logic_class, relay_server_commands, relay_spec, init_options)
     """
     # Path detection: contains '/' means external file
     if '/' in name_or_path:
@@ -61,10 +64,16 @@ def load_preset(name_or_path: str) -> PresetResult:
 
     servers_fn = getattr(module, 'servers', None)
     lclass_fn = getattr(module, 'logic_class', None)
+    relay_servers_fn = getattr(module, 'relay_servers', None)
+    relay_spec_fn = getattr(module, 'relay_spec', None)
+    init_options_fn = getattr(module, 'init_options', None)
 
     return (
         servers_fn() if servers_fn else [],
         lclass_fn() if lclass_fn else None,
+        relay_servers_fn() if relay_servers_fn else [],
+        relay_spec_fn() if relay_spec_fn else None,
+        init_options_fn() if init_options_fn else None,
     )
 
 

--- a/src/rassumfrassum/presets/emacsvue.py
+++ b/src/rassumfrassum/presets/emacsvue.py
@@ -37,28 +37,42 @@ def relay_servers():
 def _resolve_vue_plugin_location() -> str:
     """Resolve the node_modules path containing @vue/typescript-plugin.
 
-    Uses pnpm exec to resolve through pnpm's module resolution, then
-    extracts the project-level node_modules as the probe location.
-    tsserver looks for <probeLocation>/<plugin-name>, so passing the
-    project's node_modules lets it find the plugin via pnpm's symlink.
+    tsserver looks for <probeLocation>/<plugin-name>, so we need to return
+    the node_modules directory that contains @vue/typescript-plugin.
+
+    Tries plain `node` first (works with any package manager), then falls
+    back to `pnpm exec node` for pnpm's stricter module resolution.
     """
-    try:
-        result = subprocess.run(
-            ['pnpm', 'exec', 'node', '-p',
-             "require.resolve('@vue/typescript-plugin/package.json')"],
-            capture_output=True, text=True, timeout=10,
-        )
-        resolved = result.stdout.strip()
-        # In pnpm: .../node_modules/.pnpm/@vue+.../@vue/typescript-plugin/package.json
-        # Extract the project-level node_modules (before .pnpm)
-        idx = resolved.find('/node_modules/.pnpm/')
-        if idx >= 0:
-            return resolved[:idx + len('/node_modules')]
-        # Non-pnpm: .../node_modules/@vue/typescript-plugin/package.json
-        # Go up 3 levels to get node_modules
-        return str(Path(resolved).parent.parent.parent)
-    except Exception:
-        return ''
+    resolve_script = "require.resolve('@vue/typescript-plugin/package.json')"
+    commands = [
+        ['node', '-p', resolve_script],
+        ['pnpm', 'exec', 'node', '-p', resolve_script],
+    ]
+    for cmd in commands:
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=10,
+            )
+            resolved = result.stdout.strip()
+            if not resolved or result.returncode != 0:
+                continue
+            return _extract_node_modules(resolved)
+        except Exception:
+            continue
+    return ''
+
+
+def _extract_node_modules(resolved_path: str) -> str:
+    """Extract the probe-location node_modules from a resolved package path.
+
+    Handles both pnpm (.pnpm symlink structure) and standard layouts.
+    """
+    # pnpm: .../node_modules/.pnpm/@vue+.../@vue/typescript-plugin/package.json
+    idx = resolved_path.find('/node_modules/.pnpm/')
+    if idx >= 0:
+        return resolved_path[:idx + len('/node_modules')]
+    # Standard: .../node_modules/@vue/typescript-plugin/package.json
+    return str(Path(resolved_path).parent.parent.parent)
 
 
 def relay_spec():

--- a/src/rassumfrassum/presets/emacsvue.py
+++ b/src/rassumfrassum/presets/emacsvue.py
@@ -1,0 +1,93 @@
+"""Vue preset: vue-language-server + typescript-language-server with relay."""
+
+import subprocess
+from pathlib import Path
+
+from rassumfrassum.relay import RelaySpec
+
+
+def init_options():
+    """Resolve TypeScript SDK path and return initializationOptions."""
+    try:
+        proc = subprocess.run(
+            ['pnpm', 'list', '--parseable', 'typescript'],
+            capture_output=True, text=True, timeout=10,
+        )
+        first_line = proc.stdout.strip().split('\n')[-1]
+        tsdk_path = str(Path(first_line) / 'lib')
+    except Exception:
+        tsdk_path = './node_modules/typescript/lib'
+    return {'typescript': {'tsdk': tsdk_path}}
+
+
+def servers():
+    """Return vue-language-server."""
+    return [
+        ['pnpm', 'exec', 'vue-language-server', '--stdio'],
+    ]
+
+
+def relay_servers():
+    """Return typescript-language-server as relay target."""
+    return [
+        ['pnpm', 'exec', 'typescript-language-server', '--stdio'],
+    ]
+
+
+def _resolve_vue_plugin_location() -> str:
+    """Resolve the node_modules path containing @vue/typescript-plugin.
+
+    Uses pnpm exec to resolve through pnpm's module resolution, then
+    extracts the project-level node_modules as the probe location.
+    tsserver looks for <probeLocation>/<plugin-name>, so passing the
+    project's node_modules lets it find the plugin via pnpm's symlink.
+    """
+    try:
+        result = subprocess.run(
+            ['pnpm', 'exec', 'node', '-p',
+             "require.resolve('@vue/typescript-plugin/package.json')"],
+            capture_output=True, text=True, timeout=10,
+        )
+        resolved = result.stdout.strip()
+        # In pnpm: .../node_modules/.pnpm/@vue+.../@vue/typescript-plugin/package.json
+        # Extract the project-level node_modules (before .pnpm)
+        idx = resolved.find('/node_modules/.pnpm/')
+        if idx >= 0:
+            return resolved[:idx + len('/node_modules')]
+        # Non-pnpm: .../node_modules/@vue/typescript-plugin/package.json
+        # Go up 3 levels to get node_modules
+        return str(Path(resolved).parent.parent.parent)
+    except Exception:
+        return ''
+
+
+def relay_spec():
+    """Volar v3 tsserver relay specification."""
+    plugin_location = _resolve_vue_plugin_location()
+    return RelaySpec(
+        match_method='tsserver/request',
+        send_method='workspace/executeCommand',
+        respond_method='tsserver/response',
+        command='typescript.tsserverRequest',
+        init_options={
+            'plugins': [
+                {'name': '@vue/typescript-plugin', 'location': plugin_location, 'languages': ['vue']},
+            ],
+        },
+        forward_notifications=[
+            'textDocument/didOpen',
+            'textDocument/didChange',
+            'textDocument/didClose',
+        ],
+        forward_requests=[
+            'textDocument/hover',
+            'textDocument/completion',
+            'textDocument/signatureHelp',
+            'textDocument/definition',
+            'textDocument/typeDefinition',
+            'textDocument/implementation',
+            'textDocument/declaration',
+            'textDocument/references',
+            'textDocument/codeAction',
+        ],
+    )

--- a/src/rassumfrassum/rassum.py
+++ b/src/rassumfrassum/rassum.py
@@ -323,7 +323,11 @@ async def run_multiplexer(
         """
         Send a notification to a server (for use by logic layer).
         """
-        if shutting_down:
+        # FIX: The original guard `if shutting_down` dropped ALL
+        # notifications, including "exit".  Since servers wait for the
+        # exit notification after responding to shutdown, dropping it
+        # caused them to hang indefinitely, preventing clean teardown.
+        if shutting_down and method != "exit":
             debug(f"Skipping notification to server (shutting down): {method}")
             return
 

--- a/src/rassumfrassum/rassum.py
+++ b/src/rassumfrassum/rassum.py
@@ -125,18 +125,32 @@ async def launch_server(
 
 
 async def run_multiplexer(
-    server_commands: list[list[str]], opts: argparse.Namespace
+    server_commands: list[list[str]],
+    opts: argparse.Namespace,
+    relay_server_commands: list[list[str]] | None = None,
+    relay_spec=None,
 ) -> None:
     """
     Main multiplexer.
     Blocks on asyncio.gather() until a bunch of loopy async tasks complete.
 
     """
+    from .relay import RelayHandler
+
     # Launch all servers
     procs: list[InferiorProcess] = []
     for i, cmd in enumerate(server_commands):
         p = await launch_server(cmd, i)
         procs.append(p)
+
+    # Launch relay servers (separate from main procs)
+    relay_procs: list[InferiorProcess] = []
+    relay_handlers: list[RelayHandler] = []
+    if relay_server_commands and relay_spec:
+        for i, cmd in enumerate(relay_server_commands):
+            p = await launch_server(cmd, len(procs) + i)
+            relay_procs.append(p)
+            log(f"Relay server: {p.name}")
 
     # Create message router using specified logic class
     class_name = opts.logic_class
@@ -320,10 +334,23 @@ async def run_multiplexer(
         message = {
             "jsonrpc": "2.0",
             "method": method,
-            "params": payload,
         }
+        # FIX: "exit" and some other notifications have no params;
+        # omit the key entirely rather than sending "params": null.
+        if payload is not None:
+            message["params"] = payload
         await write_lsp_message(proc.stdin, message)
         log_message(f"[{proc.name}] -->", message, method)
+
+    # Create relay handlers (need request_server/notify_server defined above)
+    for rp in relay_procs:
+        handler = RelayHandler(
+            spec=relay_spec,
+            server=rp.server,
+            request_server=request_server,
+            notify_server=notify_server,
+        )
+        relay_handlers.append(handler)
 
     # Instantiate logic with callbacks
     logic = logic_class(
@@ -334,6 +361,13 @@ async def run_multiplexer(
         notify_server,
         opts,
     )
+
+    # Wire relay handlers into logic layer
+    if relay_handlers:
+        logic.relay_handlers = {
+            relay_spec.match_method: handler
+            for handler in relay_handlers
+        }
 
     def _reconstruct(ag: AggregationState) -> JSON:
         """Reconstruct payload part of response from aggregation state."""
@@ -408,9 +442,17 @@ async def run_multiplexer(
         """Handle a single client request (spawned task to avoid blocking)."""
         nonlocal shutting_down
 
+        # Initialize relay servers when client sends initialize
+        if method == "initialize" and relay_handlers:
+            for handler in relay_handlers:
+                asyncio.create_task(handler.initialize(params))
+
         # Track shutdown requests
         if method == "shutdown":
             shutting_down = True
+            # Shut down relay servers
+            for handler in relay_handlers:
+                asyncio.create_task(handler.shutdown())
 
         # Determine which servers to route to or get direct response
         result = await logic.on_client_request(
@@ -574,10 +616,20 @@ async def run_multiplexer(
         except Exception as e:
             log(f"Error handling client messages: {e}")
         finally:
-            # Close all server stdin
-            for p in procs:
+            # Close all server stdin (including relay servers)
+            for p in procs + relay_procs:
                 p.stdin.close()
                 await p.stdin.wait_closed()
+            # FIX: After closing stdin, server processes may still be
+            # alive (e.g. if they ignore exit or have slow cleanup).
+            # Their lingering stdout/stderr keeps handle_server_messages
+            # and forward_server_stderr tasks alive, blocking
+            # asyncio.gather forever.  Kill stragglers after a grace
+            # period so the process can exit cleanly.
+            await asyncio.sleep(0.5)
+            for p in procs + relay_procs:
+                if p.process.returncode is None:
+                    p.process.kill()
 
     async def handle_server_messages(proc: InferiorProcess):
         """Read from a server and route back to client."""
@@ -715,6 +767,12 @@ async def run_multiplexer(
         if not opts.quiet_server:
             tasks.append(forward_server_stderr(p))
 
+    # Relay server message handlers (so rass can read their responses/requests)
+    for p in relay_procs:
+        tasks.append(handle_server_messages(p))
+        if not opts.quiet_server:
+            tasks.append(forward_server_stderr(p))
+
     try:
         await asyncio.gather(*tasks)
     except RuntimeError as e:
@@ -722,5 +780,5 @@ async def run_multiplexer(
         sys.exit(1)
 
     # Wait for all servers to exit
-    for p in procs:
+    for p in procs + relay_procs:
         _ = await p.process.wait()

--- a/src/rassumfrassum/relay.py
+++ b/src/rassumfrassum/relay.py
@@ -1,0 +1,133 @@
+"""
+Relay server support for inter-server message forwarding.
+
+Enables one LSP server to send requests through rass to another LSP server
+and receive responses back. The primary use case is Volar v3's tsserver/request
+protocol, where the Vue LS sends requests that need to be forwarded to a
+TypeScript LS.
+"""
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Callable, Awaitable
+
+from .frassum import Server
+from .json import JSON
+from .util import debug, info, warn
+
+
+@dataclass
+class RelaySpec:
+    """Specification for how to relay messages between servers."""
+
+    match_method: str  # Notification method to intercept (e.g. "tsserver/request")
+    send_method: str  # Request method to send to relay server (e.g. "workspace/executeCommand")
+    respond_method: str  # Notification method to send back to source (e.g. "tsserver/response")
+    command: str | None = None  # Command name for workspace/executeCommand
+    init_options: JSON | None = None  # Extra initializationOptions for relay server
+    forward_notifications: list[str] | None = None  # Client notifications to forward to relay server
+    forward_requests: list[str] | None = None  # Client requests to also route to relay server
+
+
+class RelayHandler:
+    """Handles relaying notifications from source servers to a relay server."""
+
+    def __init__(
+        self,
+        spec: RelaySpec,
+        server: Server,
+        request_server: Callable[[Server, str, JSON], Awaitable[tuple[bool, JSON]]],
+        notify_server: Callable[[Server, str, JSON], Awaitable[None]],
+    ):
+        self.spec = spec
+        self.server = server
+        self.request_server = request_server
+        self.notify_server = notify_server
+        self.initialized = asyncio.Event()
+
+    async def initialize(self, client_init_params: JSON) -> tuple[bool, JSON]:
+        """Initialize the relay server using client's init params."""
+        # Build init params from client's params
+        init_params = {
+            "processId": client_init_params.get("processId"),
+            "rootUri": client_init_params.get("rootUri"),
+            "workspaceFolders": client_init_params.get("workspaceFolders"),
+            "capabilities": client_init_params.get("capabilities", {}),
+        }
+
+        # Merge preset-provided initializationOptions
+        init_options = client_init_params.get("initializationOptions") or {}
+        if self.spec.init_options:
+            init_options = {**init_options, **self.spec.init_options}
+        if init_options:
+            init_params["initializationOptions"] = init_options
+
+        info(f"Initializing relay server {self.server.name}")
+        is_error, result = await self.request_server(
+            self.server, "initialize", init_params
+        )
+
+        if not is_error:
+            # Send initialized notification
+            await self.notify_server(self.server, "initialized", {})
+            # Extract capabilities
+            caps = result.get("capabilities", {})
+            self.server.caps = caps.copy() if caps else {}
+            info(f"Relay server {self.server.name} initialized")
+        else:
+            warn(f"Relay server {self.server.name} failed to initialize: {result}")
+
+        self.initialized.set()
+        return is_error, result
+
+    async def handle_notification(self, params: JSON, source: Server) -> None:
+        """Handle an intercepted notification by relaying to the relay server.
+
+        Protocol: inbound params are [[seq, ...args]], outbound wraps args in
+        the send_method, response pairs seq with body.
+        """
+        await self.initialized.wait()
+
+        # Extract correlation data: params is [[seq, command, args]]
+        inner = params[0]
+        seq = inner[0]
+        rest = inner[1:]
+
+        # Build the outbound request
+        if self.spec.command:
+            # workspace/executeCommand style
+            outbound_params = {
+                "command": self.spec.command,
+                "arguments": list(rest),
+            }
+        else:
+            outbound_params = {"arguments": list(rest)}
+
+        debug(
+            f"Relaying {self.spec.match_method} seq={seq} to "
+            f"{self.server.name} via {self.spec.send_method}"
+        )
+
+        is_error, result = await self.request_server(
+            self.server, self.spec.send_method, outbound_params
+        )
+
+        # Build response notification back to source
+        if is_error:
+            # Don't send error responses back — the source server already
+            # handles missing responses (timeout), and sending raw error
+            # objects as the body crashes Volar (TypeError on the body shape).
+            warn(f"Relay request seq={seq} failed: {result}")
+            return
+
+        body = result.get("body", result) if isinstance(result, dict) else result
+
+        response_params = [[seq, body]]
+        debug(f"Sending {self.spec.respond_method} seq={seq} back to {source.name}")
+        await self.notify_server(source, self.spec.respond_method, response_params)
+
+    async def shutdown(self) -> None:
+        """Shut down the relay server."""
+        info(f"Shutting down relay server {self.server.name}")
+        await self.request_server(self.server, "shutdown", None)
+        await self.notify_server(self.server, "exit", None)

--- a/src/rassumfrassum/stdio.py
+++ b/src/rassumfrassum/stdio.py
@@ -50,8 +50,14 @@ async def create_stdin_reader() -> asyncio.StreamReader:
         return reader
 
 
-class _WindowsStdoutWriter:
-    """A StreamWriter-like wrapper for Windows stdout using run_in_executor."""
+class _SyncStdoutWriter:
+    """A StreamWriter-like wrapper that uses synchronous stdout writes.
+
+    asyncio's connect_write_pipe has a bug on Python 3.14 where
+    the transport fires connection_lost after the first drain on
+    FIFOs/pipes, breaking all subsequent writes.  Using synchronous
+    sys.stdout.buffer.write via run_in_executor avoids this.
+    """
 
     def __init__(self, loop):
         self._loop = loop
@@ -91,18 +97,8 @@ class _WindowsStdoutWriter:
 async def create_stdout_writer() -> asyncio.StreamWriter:
     """Create an asyncio StreamWriter for stdout.
 
-    On Windows: Uses run_in_executor with blocking writes.
-    On Unix: Direct connection to sys.stdout.
+    Uses synchronous writes via run_in_executor to avoid
+    connect_write_pipe bugs with FIFOs/pipes on Python 3.14+.
     """
     loop = asyncio.get_event_loop()
-
-    if platform.system() == 'Windows':
-        # Windows: Use custom wrapper with run_in_executor
-        return _WindowsStdoutWriter(loop)
-    else:
-        # Unix: Direct connection works fine
-        transport, protocol = await loop.connect_write_pipe(
-            asyncio.streams.FlowControlMixin, sys.stdout
-        )
-        writer = asyncio.StreamWriter(transport, protocol, None, loop)
-        return writer
+    return _SyncStdoutWriter(loop)

--- a/src/rassumfrassum/util.py
+++ b/src/rassumfrassum/util.py
@@ -6,6 +6,13 @@ ServerCommand = list[str]
 ServerCommands = list[ServerCommand]
 PresetResult = tuple[ServerCommands, type | None]
 
+# Extended preset result with relay support
+# (server_commands, logic_class, relay_server_commands, relay_spec, init_options)
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from .relay import RelaySpec
+ExtendedPresetResult = tuple[ServerCommands, type | None, ServerCommands, "RelaySpec | None", dict | None]
+
 # Log levels (lower number = higher priority)
 LOG_SILENT = 0
 LOG_WARN = 1


### PR DESCRIPTION
# Inter-server message relay

## Problem

Volar v3 (the Vue language server) expects the LSP client to act as a
relay between it and a TypeScript language server. Specifically, the Vue LS
sends `tsserver/request` notifications containing `[[seq, command, args]]`,
and expects the client to forward them to a TypeScript LS via
`workspace/executeCommand` with `typescript.tsserverRequest`, then deliver
the response back as a `tsserver/response` notification with `[[seq, body]]`.

VS Code's LSP client implements this relay natively. Emacs's eglot does
not, and has no plans to — it's a protocol extension outside the LSP spec.
Without the relay, Volar v3 blocks on `_vue:projectInfo` immediately after
`didOpen` and never responds to any requests (hover, completion, etc.),
making it completely non-functional regardless of `hybridMode` settings.

rass already sits between the editor and the language servers with
capability-based routing and response aggregation. This makes it the
natural place to implement the relay.

## Design

### New module: `relay.py`

Two new types:

- **`RelaySpec`** — a declarative description of a relay protocol: which
  notification to intercept (`match_method`), how to forward it
  (`send_method`, `command`), how to respond (`respond_method`), what
  `initializationOptions` the relay server needs (`init_options`), and
  which client notifications/requests to also forward to the relay server
  (`forward_notifications`, `forward_requests`).

- **`RelayHandler`** — manages one relay server's lifecycle. Handles
  initialization (using the client's init params plus spec-provided
  `init_options`), intercepts matched notifications, performs the
  request/response round-trip, and correlates responses back to the source
  server using the sequence ID.

Relay servers are kept separate from the primary server list — they don't
receive broadcasted messages, only explicitly forwarded ones.

### CLI: `---` separator and `--relay-*` flags

Relay servers are specified with a `---` separator (triple dash) to
distinguish them from regular `--`-separated servers:

```sh
rass -- vue-language-server --stdio --- typescript-language-server --stdio
```

The relay protocol is configured via CLI flags:

- `--relay-match METHOD` — notification to intercept
- `--relay-send METHOD` — request method to send to relay server
- `--relay-respond METHOD` — notification method to send response back
- `--relay-command CMD` — command for `workspace/executeCommand`
- `--relay-forward METHODS` — client notifications to also forward
- `--relay-forward-requests METHODS` — client requests to also route

Full Volar example from CLI:

```sh
rass \
  --relay-match tsserver/request \
  --relay-send workspace/executeCommand \
  --relay-respond tsserver/response \
  --relay-command typescript.tsserverRequest \
  --relay-forward textDocument/didOpen,textDocument/didChange,textDocument/didClose \
  --relay-forward-requests textDocument/hover,textDocument/completion \
  --init-options '{"typescript":{"tsdk":"./node_modules/typescript/lib"}}' \
  -- vue-language-server --stdio \
  --- typescript-language-server --stdio
```

### CLI: `--init-options` and `--relay-init-options`

Two flags for injecting `initializationOptions` from the command line:

- `--init-options JSON` — merged into the `initialize` request sent to
  primary servers (e.g. the `typescript.tsdk` path that Volar requires).
- `--relay-init-options JSON` — merged into the relay server's
  `initializationOptions` (e.g. tsserver plugin configuration).

When a preset also provides init options, the preset values are the base
and CLI values override on top.

### Preset hooks: `relay_servers()`, `relay_spec()`, `init_options()`

Presets can now export three new functions:

- `relay_servers()` — returns server commands for relay servers
- `relay_spec()` — returns a `RelaySpec`
- `init_options()` — returns a dict to merge into primary server
  `initializationOptions`

### Integration into existing routing (`frassum.py`, `rassum.py`)

- `on_client_request` now appends relay servers to the routing result for
  methods listed in `forward_requests`, so requests like hover and
  completion reach both the Vue LS and the TypeScript LS.
- `on_client_notification` forwards `didOpen`/`didChange`/`didClose` to
  relay servers (waiting for relay init to complete first).
- `on_server_notification` intercepts the matched notification method and
  dispatches it to the relay handler instead of forwarding to the client.
- `run_multiplexer` manages relay server lifecycle: launch, initialize on
  client init, message handling, shutdown, and cleanup (including killing
  straggler processes after a grace period).

### New preset: `emacsvue`

Bundles the full Volar v3 relay configuration: vue-language-server as
primary, typescript-language-server as relay target, `tsdk` path
resolution, `@vue/typescript-plugin` probe location, and all the
notification/request forwarding needed for a working Vue editing
experience in Emacs.

### Misc fixes

- `notify_server` no longer drops the `exit` notification during shutdown
  (servers need it to terminate after responding to `shutdown`).
- `notify_server` omits the `params` key when payload is `None` (required
  by the `exit` notification spec).
- `create_stdout_writer` uses synchronous writes via `run_in_executor` on
  all platforms to avoid a `connect_write_pipe` bug on Python 3.14.
- `test/run-all.sh` uses `-perm +0111` instead of `-executable` (macOS
  `find` compatibility).

### Unit Tests to be added shortly if changes are welcome

## Files changed

| File | What |
|---|---|
| `relay.py` | New module: `RelaySpec` + `RelayHandler` |
| `rassum.py` | Relay server launch, init, message handling, shutdown |
| `frassum.py` | Relay-aware routing, notification forwarding, init_options merging |
| `main.py` | `---` separator, `--relay-*` / `--init-options` flags |
| `preset.py` | Read `relay_servers()`, `relay_spec()`, `init_options()` from presets |
| `util.py` | Extended preset result type |
| `presets/emacsvue.py` | New preset for Volar v3 + tsserver relay |
| `stdio.py` | Stdout writer fix for Python 3.14 |
| `README.md` | Document emacsvue preset |
| `test/run-all.sh` | macOS find compatibility |
