### PR TITLE
Look up alternative eslint-language-server name in $PATH

### DIFF
--- a/src/rassumfrassum/presets/tslint.py
+++ b/src/rassumfrassum/presets/tslint.py
@@ -1,6 +1,7 @@
 """TypeScript preset: typescript-language-server + eslint-language-server."""
 
 import os
+import shutil
 
 from rassumfrassum.frassum import LspLogic, Server
 from rassumfrassum.json import JSON
@@ -87,9 +88,14 @@ class TypeScriptLogic(LspLogic):
 
 def servers():
     """Return eslint-language-server."""
+
+    eslint_server = 'vscode-eslint-language-server'
+    if shutil.which(eslint_server) is None:
+        eslint_server = 'eslint-language-server'
+
     return [
         ['typescript-language-server', '--stdio'],
-        ['eslint-language-server', '--stdio'],
+        [eslint_server, '--stdio'],
     ]
 
 


### PR DESCRIPTION
The other half of #42 

This currently _doesn't_ check if the fallback is available, since I figured the only thing it could do is throw an error, which it will shortly anyway...