### PR TITLE
fix: treat capability `{}` as supported

### DIFF
--- a/src/rassumfrassum/frassum.py
+++ b/src/rassumfrassum/frassum.py
@@ -161,7 +161,7 @@ class LspLogic:
             'textDocument/declaration': 'declarationProvider',
             'textDocument/references': 'referencesProvider',
         }.get(method):
-            return [s for s in servers if s.caps.get(cap)]
+            return [s for s in servers if s.caps.get(cap) is not None]
 
         elif method == 'workspace/executeCommand':
             probe = self.commands_map.get(cast(str, params.get('command')))
@@ -190,7 +190,7 @@ class LspLogic:
             'textDocument/documentSymbol': 'documentSymbolProvider',
         }.get(method):
             for s in servers:
-                if s.caps.get(cap):
+                if s.caps.get(cap) is not None:
                     return [s]
             return []
 


### PR DESCRIPTION
* src/rassumfrassum/frassum.py (LspLogic): match capability `{}` as supported.

LSP server capabilities of type `boolean | <Options>` may be sent as an empty object when the options interface (e.g. `DefinitionOptions`) has only optional fields. The filter `s.caps.get(cap)` rejected those because `{}` is falsy in Python, unlike JS where `{}` is truthy.

Reference: vscode-languageserver-node uses `!capability` to mean unsupported (capability undefined or `false`); a non-boolean object is treated as the options struct and the request is accepted. [^1]

Bicep.LangServer for instance advertises `definitionProvider: {}`, so a `textDocument/definition` request produced `[rass] no servers to handle ...`. Same for typeDefinition, implementation, declaration, references, rename and formatting.

Use `is not None` so any present capability counts.

[^1]: https://github.com/microsoft/vscode-languageserver-node/blob/main/client/src/common/features.ts
    `Feature.getRegistrationOptions`