### PR TITLE
fix: use spec-compliant JSON-RPC error envelope for unhandled methods

### DIFF
--- a/src/rassumfrassum/rassum.py
+++ b/src/rassumfrassum/rassum.py
@@ -460,12 +460,13 @@ async def run_multiplexer(
                     set(target_procs),
                 )
         else:
-            # respond with rass error
             await _respond_to_client(
                 req_id,
                 {
-                    "error": f"[rass] no servers to handle "
-                    f"method='{method}' with params='{params}'!",
+                    "error": {
+                        "code": -32601,
+                        "message": f"[rass] no servers to handle '{method}'",
+                    }
                 },
                 method,
             )


### PR DESCRIPTION
When no server in the preset handled a request, rass replied with `{"error": "<string>"}`. JSON-RPC 2.0 §5 requires the `error` member to be an object with integer `code` and string `message` fields. [^1] A bare string violates the protocol and crashes strict clients.

Concrete failure in eglot:

```
Error running timer: (wrong-type-argument listp
  "[rass] no servers to handle method='textDocument/codeAction' ...")
```

When eglot tries to parse `error` as a plist while the `error` is a string. Easy to trigger with `sideline-eglot` polling `textDocument/codeAction` against a preset whose servers don't advertise `codeActionProvider` (e.g. I've got a JSON preset with just `efm-langserver`).

The `-32601 MethodNotFound` was used since no server in the preset announced support for the requested method. `-32803 RequestFailed` is also a plausible LSP-layered alternative (the method is known to the dispatch table, and the runtime condition prevents fulfillment); happy to swap.

[^1]: https://www.jsonrpc.org/specification#error_object