### PR TITLE
Add codeAction settings for TSLint preset

### DIFF
--- a/src/rassumfrassum/presets/tslint.py
+++ b/src/rassumfrassum/presets/tslint.py
@@ -39,6 +39,10 @@ def _eslint_config(workspace_folder: dict | None = None) -> dict:
         'rulesCustomizations': [],
         'nodePath': None,
         'experimental': {},
+        'codeAction': {
+            'disableRuleComment': { 'enable': True, 'location': 'separateLine', },
+            'showDocumentation': { 'enable': True },
+        },
     }
     if workspace_folder:
         config['workspaceFolder'] = workspace_folder


### PR DESCRIPTION
Eslint requires a `codeAction` configuration to be set.

Otherwise you end up with error like this, when you try to apply eslint quick fixes:

```
  e[22:31:49.396] [eslint-language-server#1] <-- textDocument/codeAction[24] {"jsonrpc": "2.0", "id": 24, "error": {"code": -32603, "message": "Request
  textDocument/codeAction failed with message: Cannot read properties of undefined (reading 'disableRuleComment')"}}
```