### PR TITLE
Test on Linux, macOS and Windows in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,16 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.10', '3.13']
 
     steps:
     - uses: actions/checkout@v4
@@ -16,9 +22,10 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: ${{ matrix.python-version }}
 
     - name: Run tests
+      shell: bash
       # The vuetail test npm-installs real language servers in its
       # fixture, so it needs more than the default 10s
       run: TIMEOUT=180 test/run-all.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,11 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    # Windows is informational for now: the Windows stdio machinery is
+    # known-fragile (see test2.py) and the timing-sensitive
+    # drop-tardy-notification test is flaky there
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,4 +19,6 @@ jobs:
         python-version: '3.10'
 
     - name: Run tests
-      run: test/run-all.sh
+      # The vuetail test npm-installs real language servers in its
+      # fixture, so it needs more than the default 10s
+      run: TIMEOUT=180 test/run-all.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,5 +27,7 @@ jobs:
     - name: Run tests
       shell: bash
       # The vuetail test npm-installs real language servers in its
-      # fixture, so it needs more than the default 10s
-      run: TIMEOUT=180 test/run-all.sh
+      # fixture, so it needs more than the default 10s.  Lower
+      # parallelism: the timing-sensitive tests get flaky when 8 of
+      # them compete for the runners' 2 cores.
+      run: TIMEOUT=180 BATCH_SIZE=4 test/run-all.sh

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ tweaking.  Many presets are simple and are just Python files with a
 
 So-called hooking presets hook into LSP messages to hide the typical
 initialization/configuration pains from clients, see
-[vue.py][vue-preset].
+[vuetail.py][vue-preset].
 
 ### Using Presets
 
@@ -98,7 +98,14 @@ are very simple, and some are slightly more complex.
 * `tsbiome`: for `typescript-language-server` + `biome` (simple)
 
 * `vuetail`: for `vue-language-server` + `tailwindcss-language-server`
-  (complex)
+  (complex).  With `vue-language-server` v3, this also launches
+  `typescript-language-server` (>= 4.4) and brokers the
+  [`tsserver/request` protocol extension][tsserver-request] between
+  the two, something Vue v3 needs and which only VSCode-like clients
+  do natively.  Both servers must be findable in `PATH`, and
+  `typescript` must be importable by `vue-language-server` (it's a
+  regular dependency in most Vue projects).  `vue-language-server` v2
+  also works, and there the TypeScript server isn't needed.
   
 The "complex" presets use special hooks of the 'LspLogic' class to
 massage the exchanged messages.  The servers in question (usually the
@@ -355,7 +362,8 @@ in the `eglot-handle-notification` method for
 [neovim]: https://neovim.io/
 [codebook]: https://github.com/blopker/codebook
 [typos]: https://github.com/tekumara/typos-lsp
-[vue-preset]: https://github.com/joaotavora/rassumfrassum/blob/master/src/rassumfrassum/presets/vue.py
+[vue-preset]: https://github.com/joaotavora/rassumfrassum/blob/master/src/rassumfrassum/presets/vuetail.py
+[tsserver-request]: https://github.com/vuejs/language-tools/discussions/5456
 [python-preset]: https://github.com/joaotavora/rassumfrassum/blob/master/src/rassumfrassum/presets/python.py
 [basedruff-preset]: https://github.com/joaotavora/rassumfrassum/blob/master/src/rassumfrassum/presets/basedruff.py
 [ts-preset]: https://github.com/joaotavora/rassumfrassum/blob/master/src/rassumfrassum/presets/ts.py

--- a/src/rassumfrassum/presets/vuetail.py
+++ b/src/rassumfrassum/presets/vuetail.py
@@ -1,15 +1,82 @@
-"""Vue preset: vue-language-server + tailwindcss-language-server with custom logic."""
+"""Vue preset: vue-language-server + tailwindcss-language-server.
+
+With vue-language-server v3, a typescript-language-server (>= 4.4) is
+also launched, because v3 no longer runs its own tsserver: it expects
+the *client* to broker its 'tsserver/request' notifications over to a
+TypeScript server loaded with the '@vue/typescript-plugin' (see
+https://github.com/vuejs/language-tools/discussions/5456).  Editors
+like Emacs's Eglot don't implement this protocol extension, so this
+preset does it for them (Vue3Logic).
+
+With vue-language-server v2, behaves as before: just the Vue and
+Tailwind servers, with v2's 'hybridMode' turned off (Vue2Logic).
+"""
 
 import asyncio
+import json
+import os
+import shutil
+import subprocess
+from functools import cache
 from pathlib import Path
+from typing import cast
 
 from rassumfrassum.frassum import LspLogic, Server
 from rassumfrassum.json import JSON
-from rassumfrassum.util import dmerge
+from rassumfrassum.util import dmerge, warn
 
 
-class VueLogic(LspLogic):
-    """Custom logic LSP for Vue-friendly servers."""
+@cache
+def _vue_server_info() -> tuple[int, str | None]:
+    """Find and identify the vue-language-server in PATH.
+
+    Returns (major_version, package_dir) where package_dir is the
+    '@vue/language-server' installation directory, suitable as a
+    tsserver plugin probe location for '@vue/typescript-plugin' (which
+    is a dependency of '@vue/language-server').  Returns (0, None) if
+    nothing can be found.
+    """
+    # Resolve the executable's symlink and walk up to the containing
+    # npm package.
+    if exe := shutil.which('vue-language-server'):
+        for dir in Path(os.path.realpath(exe)).parents:
+            pkgjson = dir / 'package.json'
+            if not pkgjson.exists():
+                continue
+            try:
+                pkg = json.loads(pkgjson.read_text())
+                if pkg.get('name') == '@vue/language-server':
+                    return (int(pkg['version'].split('.')[0]), str(dir))
+            except (OSError, ValueError, KeyError):
+                pass
+            break
+
+    # Some installations (e.g. Windows .cmd shims) defeat the above.
+    # Ask node to resolve the package from the current project.
+    try:
+        proc = subprocess.run(
+            ['node', '-p', "require.resolve('@vue/language-server/package.json')"],
+            capture_output=True, text=True, timeout=10,
+        )
+        pkgjson = Path(proc.stdout.strip())
+        pkg = json.loads(pkgjson.read_text())
+        return (int(pkg['version'].split('.')[0]), str(pkgjson.parent))
+    except (OSError, ValueError, KeyError, subprocess.TimeoutExpired):
+        pass
+
+    # Last resort: ask the executable itself (no plugin location).
+    try:
+        proc = subprocess.run(
+            ['vue-language-server', '--version'],
+            capture_output=True, text=True, timeout=10,
+        )
+        return (int(proc.stdout.strip().split('.')[0]), None)
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        return (0, None)
+
+
+class Vue2Logic(LspLogic):
+    """Custom logic for vue-language-server v2 + friends."""
 
     async def on_client_request(
         self, method: str, params: JSON, servers: list[Server]
@@ -39,14 +106,108 @@ class VueLogic(LspLogic):
         return await super().on_client_request(method, params, servers)
 
 
+# Backward-compatible alias (this used to be the only logic class here)
+VueLogic = Vue2Logic
+
+
+class Vue3Logic(LspLogic):
+    """Custom logic for vue-language-server v3 + friends.
+
+    Brokers vue-language-server's 'tsserver/request' protocol
+    extension to the typescript-language-server, which answers it via
+    the 'typescript.tsserverRequest' command of the
+    '@vue/typescript-plugin' loaded into its tsserver.
+    """
+
+    def __init__(self, servers: list[Server], *args):
+        super().__init__(servers, *args)
+        # Order fixed by servers() below
+        self.vue = servers[0]
+        self.ts = servers[1]
+
+    async def on_client_request(
+        self, method: str, params: JSON, servers: list[Server]
+    ):
+        if method == 'initialize':
+            _, location = _vue_server_info()
+            params['initializationOptions'] = dmerge(
+                params.get('initializationOptions') or {},
+                {
+                    # Tells typescript-language-server to load the
+                    # plugin that makes tsserver understand .vue files.
+                    # The other servers ignore this key.
+                    'plugins': [
+                        {
+                            'name': '@vue/typescript-plugin',
+                            'location': location,
+                            'languages': ['vue'],
+                            'configNamespace': 'typescript',
+                        }
+                    ],
+                },
+            )
+        # In the v3 architecture the TypeScript server, not
+        # vue-language-server, answers for the <script> parts of .vue
+        # files, so route these to every capable server instead of
+        # just the primary.
+        elif cap := {
+            'textDocument/hover': 'hoverProvider',
+            'textDocument/signatureHelp': 'signatureHelpProvider',
+        }.get(method):
+            return [s for s in servers if s.caps.get(cap) is not None]
+        return await super().on_client_request(method, params, servers)
+
+    async def on_server_notification(
+        self, method: str, params: JSON, source: Server
+    ) -> None:
+        if method == 'tsserver/request' and source is self.vue:
+            if not isinstance(params, list):
+                warn(f"Malformed tsserver/request: {params}")
+                return
+            for request in params:
+                seq, command, payload = (list(request) + [None] * 3)[:3]
+                # Each round-trip in its own task: brokering must not
+                # block other traffic, and replies may come out of order.
+                asyncio.create_task(self._broker(seq, command, payload))
+            return
+        await super().on_server_notification(method, params, source)
+
+    async def _broker(self, seq, command, payload) -> None:
+        """Do one 'tsserver/request' round-trip."""
+        is_error, response = await self.request_server(
+            self.ts,
+            'workspace/executeCommand',
+            {
+                'command': 'typescript.tsserverRequest',
+                'arguments': [command, payload],
+            },
+        )
+        if is_error:
+            warn(f"tsserver relay: '{command}' failed: {response}")
+        body = None if is_error else (cast(JSON, response) or {}).get('body')
+        # Always answer, else vue-language-server hangs forever
+        await self.notify_server(self.vue, 'tsserver/response', [[seq, body]])
+
+
 def servers():
-    """Return vue-language-server and tailwindcss-language-server."""
-    return [
-        ['vue-language-server', '--stdio'],
-        ['tailwindcss-language-server', '--stdio'],
-    ]
+    """Vue + Tailwind servers, plus TypeScript for vue-language-server v3."""
+    major, _ = _vue_server_info()
+    vue = ['vue-language-server', '--stdio']
+    tailwind = ['tailwindcss-language-server', '--stdio']
+    if major >= 3:
+        if shutil.which('typescript-language-server') is None:
+            warn(
+                "vue-language-server v3 needs typescript-language-server"
+                " (>= 4.4) in PATH.  Try"
+                " 'npm install -g typescript-language-server'."
+            )
+        return [vue, ['typescript-language-server', '--stdio'], tailwind]
+    if major == 0:
+        warn("Can't find/identify vue-language-server, assuming v2")
+    return [vue, tailwind]
 
 
 def logic_class():
-    """Use custom VueLogic."""
-    return VueLogic
+    """Vue3Logic or Vue2Logic, depending on the installed server."""
+    major, _ = _vue_server_info()
+    return Vue3Logic if major >= 3 else Vue2Logic

--- a/src/rassumfrassum/presets/vuetail.py
+++ b/src/rassumfrassum/presets/vuetail.py
@@ -75,6 +75,33 @@ def _vue_server_info() -> tuple[int, str | None]:
         return (0, None)
 
 
+def _find_tsdk() -> str | None:
+    """Find a usable TypeScript lib directory for vue-language-server.
+
+    vue-language-server v3 does require('typescript') from its own
+    installation unless told otherwise with --tsdk, and npm may have
+    satisfied that peer dependency with something unusable, e.g. the
+    API-less TypeScript 7 native preview.  Prefer the project's own
+    TypeScript ('typescript.js' present distinguishes a real one).
+    """
+    cwd = Path.cwd()
+    for dir in [cwd, *cwd.parents]:
+        cand = dir / 'node_modules' / 'typescript' / 'lib'
+        if (cand / 'typescript.js').exists():
+            return str(cand)
+    try:
+        proc = subprocess.run(
+            ['npm', 'root', '--global'],
+            capture_output=True, text=True, timeout=10,
+        )
+        cand = Path(proc.stdout.strip()) / 'typescript' / 'lib'
+        if (cand / 'typescript.js').exists():
+            return str(cand)
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
 class Vue2Logic(LspLogic):
     """Custom logic for vue-language-server v2 + friends."""
 
@@ -195,6 +222,14 @@ def servers():
     vue = ['vue-language-server', '--stdio']
     tailwind = ['tailwindcss-language-server', '--stdio']
     if major >= 3:
+        if tsdk := _find_tsdk():
+            vue.append(f'--tsdk={tsdk}')
+        else:
+            warn(
+                "Can't find a usable TypeScript for vue-language-server."
+                "  Install one in the project or with"
+                " 'npm install -g typescript@5'."
+            )
         if shutil.which('typescript-language-server') is None:
             warn(
                 "vue-language-server v3 needs typescript-language-server"

--- a/src/rassumfrassum/presets/vuetail.py
+++ b/src/rassumfrassum/presets/vuetail.py
@@ -75,6 +75,7 @@ def _vue_server_info() -> tuple[int, str | None]:
         return (0, None)
 
 
+@cache
 def _find_tsdk() -> str | None:
     """Find a usable TypeScript lib directory for vue-language-server.
 
@@ -85,8 +86,19 @@ def _find_tsdk() -> str | None:
     TypeScript ('typescript.js' present distinguishes a real one).
     """
     cwd = Path.cwd()
-    for dir in [cwd, *cwd.parents]:
-        cand = dir / 'node_modules' / 'typescript' / 'lib'
+    # At cwd or above it, but also shallowly below it: LSP clients
+    # commonly launch servers at the repository root with the JS app
+    # in a subdirectory.
+    candidates = [
+        dir / 'node_modules' / 'typescript' / 'lib'
+        for dir in [cwd, *cwd.parents]
+    ]
+    for pattern in (
+        '*/node_modules/typescript/lib',
+        '*/*/node_modules/typescript/lib',
+    ):
+        candidates.extend(sorted(cwd.glob(pattern)))
+    for cand in candidates:
         if (cand / 'typescript.js').exists():
             return str(cand)
     try:
@@ -157,21 +169,28 @@ class Vue3Logic(LspLogic):
     ):
         if method == 'initialize':
             _, location = _vue_server_info()
+            options = {
+                # Tells typescript-language-server to load the
+                # plugin that makes tsserver understand .vue files.
+                # The other servers ignore this key.
+                'plugins': [
+                    {
+                        'name': '@vue/typescript-plugin',
+                        'location': location,
+                        'languages': ['vue'],
+                        'configNamespace': 'typescript',
+                    }
+                ],
+            }
+            # Give typescript-language-server the same real tsserver
+            # found for --tsdk (see _find_tsdk): its own lookup has
+            # the same TypeScript 7 stub pitfalls.
+            if tsdk := _find_tsdk():
+                tsserver_js = Path(tsdk) / 'tsserver.js'
+                if tsserver_js.exists():
+                    options['tsserver'] = {'path': str(tsserver_js)}
             params['initializationOptions'] = dmerge(
-                params.get('initializationOptions') or {},
-                {
-                    # Tells typescript-language-server to load the
-                    # plugin that makes tsserver understand .vue files.
-                    # The other servers ignore this key.
-                    'plugins': [
-                        {
-                            'name': '@vue/typescript-plugin',
-                            'location': location,
-                            'languages': ['vue'],
-                            'configNamespace': 'typescript',
-                        }
-                    ],
-                },
+                params.get('initializationOptions') or {}, options
             )
         # In the v3 architecture the TypeScript server, not
         # vue-language-server, answers for the <script> parts of .vue

--- a/src/rassumfrassum/stdio.py
+++ b/src/rassumfrassum/stdio.py
@@ -53,11 +53,10 @@ async def create_stdin_reader() -> asyncio.StreamReader:
 class _SyncStdoutWriter:
     """A StreamWriter-like wrapper using synchronous stdout writes.
 
-    asyncio's connect_write_pipe is buggy with FIFOs/pipes on some
-    platforms (the transport fires connection_lost after the first
-    drain, breaking all subsequent writes; seen at least on macOS and
-    on Python 3.14).  Synchronous sys.stdout.buffer.write via
-    run_in_executor avoids this.
+    Used on Windows, where asyncio can't connect pipe transports to
+    stdio, and on macOS, where kqueue-based write transports are
+    broken for FIFOs (connection_lost fires right after the first
+    drain, breaking all subsequent writes).
     """
 
     def __init__(self, loop):
@@ -102,8 +101,17 @@ class _SyncStdoutWriter:
 async def create_stdout_writer() -> asyncio.StreamWriter:
     """Create an asyncio StreamWriter for stdout.
 
-    Uses synchronous writes via run_in_executor on all platforms, see
+    On Windows and macOS: synchronous writes via run_in_executor, see
     _SyncStdoutWriter.
+    On other Unixes: direct connection to sys.stdout.
     """
     loop = asyncio.get_event_loop()
-    return _SyncStdoutWriter(loop)
+
+    if platform.system() in ('Windows', 'Darwin'):
+        return _SyncStdoutWriter(loop)
+    else:
+        transport, protocol = await loop.connect_write_pipe(
+            asyncio.streams.FlowControlMixin, sys.stdout
+        )
+        writer = asyncio.StreamWriter(transport, protocol, None, loop)
+        return writer

--- a/src/rassumfrassum/stdio.py
+++ b/src/rassumfrassum/stdio.py
@@ -50,12 +50,20 @@ async def create_stdin_reader() -> asyncio.StreamReader:
         return reader
 
 
-class _WindowsStdoutWriter:
-    """A StreamWriter-like wrapper for Windows stdout using run_in_executor."""
+class _SyncStdoutWriter:
+    """A StreamWriter-like wrapper using synchronous stdout writes.
+
+    asyncio's connect_write_pipe is buggy with FIFOs/pipes on some
+    platforms (the transport fires connection_lost after the first
+    drain, breaking all subsequent writes; seen at least on macOS and
+    on Python 3.14).  Synchronous sys.stdout.buffer.write via
+    run_in_executor avoids this.
+    """
 
     def __init__(self, loop):
         self._loop = loop
         self._buffer = bytearray()
+        self._lock = asyncio.Lock()
 
     def write(self, data):
         """Add data to the buffer."""
@@ -77,7 +85,10 @@ class _WindowsStdoutWriter:
             except Exception:
                 pass
 
-        await self._loop.run_in_executor(None, blocking_write, data)
+        # Serialize: concurrent executor writes could hit the pipe out
+        # of order (pipe writes are only atomic up to PIPE_BUF).
+        async with self._lock:
+            await self._loop.run_in_executor(None, blocking_write, data)
 
     def close(self):
         """Close the writer."""
@@ -91,18 +102,8 @@ class _WindowsStdoutWriter:
 async def create_stdout_writer() -> asyncio.StreamWriter:
     """Create an asyncio StreamWriter for stdout.
 
-    On Windows: Uses run_in_executor with blocking writes.
-    On Unix: Direct connection to sys.stdout.
+    Uses synchronous writes via run_in_executor on all platforms, see
+    _SyncStdoutWriter.
     """
     loop = asyncio.get_event_loop()
-
-    if platform.system() == 'Windows':
-        # Windows: Use custom wrapper with run_in_executor
-        return _WindowsStdoutWriter(loop)
-    else:
-        # Unix: Direct connection works fine
-        transport, protocol = await loop.connect_write_pipe(
-            asyncio.streams.FlowControlMixin, sys.stdout
-        )
-        writer = asyncio.StreamWriter(transport, protocol, None, loop)
-        return writer
+    return _SyncStdoutWriter(loop)

--- a/test/run-all.sh
+++ b/test/run-all.sh
@@ -5,6 +5,17 @@ TIMEOUT_SCALE=${TIMEOUT_SCALE:-1.0}
 TIMEOUT=$(awk "BEGIN {printf \"%.1f\", ${TIMEOUT:-10} * $TIMEOUT_SCALE}")
 BATCH_SIZE=${BATCH_SIZE:-8}
 
+# macOS doesn't ship a 'timeout' command (GitHub's macOS runners do
+# have GNU coreutils' gtimeout, though)
+if ! command -v timeout >/dev/null 2>&1; then
+    if command -v gtimeout >/dev/null 2>&1; then
+        timeout() { gtimeout "$@"; }
+    else
+        echo "WARNING: no timeout command found, tests may hang" >&2
+        timeout() { shift; "$@"; }
+    fi
+fi
+
 # Colorize helper (set to false to disable colors)
 USE_COLOR=true
 colorize() {

--- a/test/run-all.sh
+++ b/test/run-all.sh
@@ -5,14 +5,27 @@ TIMEOUT_SCALE=${TIMEOUT_SCALE:-1.0}
 TIMEOUT=$(awk "BEGIN {printf \"%.1f\", ${TIMEOUT:-10} * $TIMEOUT_SCALE}")
 BATCH_SIZE=${BATCH_SIZE:-8}
 
-# macOS doesn't ship a 'timeout' command (GitHub's macOS runners do
-# have GNU coreutils' gtimeout, though)
+# macOS doesn't ship a 'timeout' command (not even GitHub's macOS
+# runners have coreutils), so fall back to gtimeout or to a pure-bash
+# equivalent that keeps coreutils' "124 means timed out" convention.
 if ! command -v timeout >/dev/null 2>&1; then
     if command -v gtimeout >/dev/null 2>&1; then
         timeout() { gtimeout "$@"; }
     else
-        echo "WARNING: no timeout command found, tests may hang" >&2
-        timeout() { shift; "$@"; }
+        timeout() {
+            perl -e '
+                my $t = shift @ARGV;
+                my $pid = fork // die "fork: $!";
+                if (!$pid) { setpgrp(0, 0); exec @ARGV or exit 127; }
+                $SIG{ALRM} = sub {
+                    kill "TERM", -$pid; sleep 2; kill "KILL", -$pid;
+                    exit 124;
+                };
+                alarm int($t + 0.5);
+                waitpid($pid, 0);
+                exit(($? & 127) ? 128 + ($? & 127) : $? >> 8);
+            ' "$@"
+        }
     fi
 fi
 

--- a/test/run-all.sh
+++ b/test/run-all.sh
@@ -22,8 +22,9 @@ colorize() {
 export -f colorize
 export USE_COLOR
 
-# Find all test directories (those containing run.sh)
-TEST_DIRS=$(find test -mindepth 2 -maxdepth 2 -name "run.sh" -type f -executable | sed 's|/run.sh$||' | sort)
+# Find all test directories (those containing run.sh).
+# (-perm -u+x instead of -executable: works in BSD/macOS find too)
+TEST_DIRS=$(find test -mindepth 2 -maxdepth 2 -name "run.sh" -type f -perm -u+x | sed 's|/run.sh$||' | sort)
 
 if [ -z "$TEST_DIRS" ]; then
     echo "No tests found"

--- a/test/server-crash/run.sh
+++ b/test/server-crash/run.sh
@@ -4,8 +4,22 @@ cd $(dirname "$0")
 # Server s2 will crash after initialization
 # We expect rass to exit with error code 1
 
+# On Windows rass can't make its fatal exit while the stdin-reading
+# executor thread is blocked (see WINDOWS_KLUDGE in test2.py), so this
+# scenario isn't testable there
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || -n "$WINDIR" ]]; then
+    echo "Windows, skipping test" >&2
+    exit 77
+fi
+
+# The client waits for EOF from rass, which macOS's kqueue never
+# reports on FIFOs, so cap its wait.  rass's exit code decides the
+# test and yoyo.sh's pipefail propagates the pipeline's rightmost
+# (i.e. rass's) non-zero exit status.
+TO=$(command -v timeout || command -v gtimeout || true)
+
 set +e
-../yoyo.sh ./client.py --rass-- \
+../yoyo.sh ${TO:+"$TO" 5} ./client.py --rass-- \
     -- python ./server.py --name s1 \
     -- python ./server.py --name s2 --crash-after-init
 EXIT_CODE=$?

--- a/test/server-crash/run.sh
+++ b/test/server-crash/run.sh
@@ -13,13 +13,12 @@ if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || -n "$WINDIR" ]]; then
 fi
 
 # The client waits for EOF from rass, which macOS's kqueue never
-# reports on FIFOs, so cap its wait.  rass's exit code decides the
-# test and yoyo.sh's pipefail propagates the pipeline's rightmost
-# (i.e. rass's) non-zero exit status.
-TO=$(command -v timeout || command -v gtimeout || true)
-
+# reports on FIFOs, so cap its wait (with perl's alarm, since macOS
+# has no 'timeout' command).  rass's exit code decides the test and
+# yoyo.sh's pipefail propagates the pipeline's rightmost (i.e.
+# rass's) non-zero exit status.
 set +e
-../yoyo.sh ${TO:+"$TO" 5} ./client.py --rass-- \
+../yoyo.sh perl -e 'alarm shift; exec @ARGV' 5 ./client.py --rass-- \
     -- python ./server.py --name s1 \
     -- python ./server.py --name s2 --crash-after-init
 EXIT_CODE=$?

--- a/test/vuetail/client.py
+++ b/test/vuetail/client.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Test client for the vuetail preset with vue-language-server v3.
+
+vue-language-server v3 is unusable unless the client (here, rass
+itself via the vuetail preset) brokers its 'tsserver/request'
+notifications to a typescript-language-server: it blocks right after
+'didOpen' waiting for project info and never answers anything.  So
+simply getting answers out of it is proof that the brokering works.
+"""
+
+import asyncio
+import json
+import os
+
+from rassumfrassum.test2 import LspTestEndpoint, log, scaled_timeout
+
+
+async def pump_until_response(client: LspTestEndpoint, req_id: int):
+    """Wait for the response to req_id, babysitting the servers meanwhile.
+
+    The real-world servers in this test (tailwind especially) ask for
+    'workspace/configuration' and other client services at their own
+    leisure, so answer those blandly instead of expecting them at
+    fixed points like simpler tests do.
+    """
+    while True:
+        msg = await client.read_message(timeout_sec=scaled_timeout(60))
+        if 'id' in msg and 'method' in msg:
+            # A server-to-client request: answer blandly
+            if msg['method'] == 'workspace/configuration':
+                items = msg.get('params', {}).get('items', [])
+                result = [None] * len(items)
+            else:
+                result = None
+            await client.respond(msg['id'], result)
+            log(client.name, f"Answered server request {msg['method']}")
+        elif 'method' in msg:
+            log(client.name, f"Skipping notification {msg['method']}")
+        elif msg.get('id') == req_id:
+            return msg
+        else:
+            log(client.name, f"Skipping response id={msg.get('id')}")
+
+
+def symbol_names(symbols) -> set[str]:
+    """Collect names from DocumentSymbol[]/SymbolInformation[]."""
+    names = set()
+    for s in symbols or []:
+        names.add(s.get('name'))
+        names |= symbol_names(s.get('children'))
+    return names
+
+
+async def main():
+    client = await LspTestEndpoint.create()
+
+    test_dir = os.path.dirname(os.path.abspath(__file__))
+    test_project = os.path.join(test_dir, "fixture")
+    os.chdir(test_project)
+
+    capabilities = {
+        'workspace': {'configuration': True},
+        'textDocument': {
+            'publishDiagnostics': {'versionSupport': False},
+            'hover': {'contentFormat': ['markdown', 'plaintext']},
+        },
+    }
+
+    init_response = await client.initialize(
+        capabilities=capabilities, rootUri=f"file://{test_project}"
+    )
+    server_caps = init_response.get('result', {}).get('capabilities', {})
+    assert server_caps.get('documentSymbolProvider'), \
+        "Expected documentSymbolProvider in merged capabilities"
+    assert server_caps.get('hoverProvider'), \
+        "Expected hoverProvider in merged capabilities"
+
+    # Open the .vue single-file component
+    file_path = os.path.join(test_project, "src/App.vue")
+    with open(file_path, 'r') as f:
+        file_content = f.read()
+    file_uri = f"file://{file_path}"
+
+    log(client.name, f"Opening {file_uri}")
+    await client.notify(
+        'textDocument/didOpen',
+        {
+            'textDocument': {
+                'uri': file_uri, 'languageId': 'vue',
+                'version': 1, 'text': file_content,
+            }
+        },
+    )
+
+    # vue-language-server v3 won't answer this (or anything) unless
+    # its tsserver/request dance succeeded.
+    log(client.name, "Requesting documentSymbol...")
+    req_id = await client.request(
+        'textDocument/documentSymbol', {'textDocument': {'uri': file_uri}}
+    )
+    response = await pump_until_response(client, req_id)
+    names = symbol_names(response.get('result'))
+    log(client.name, f"Got symbols: {names}")
+    assert 'greeting' in names and 'shout' in names, \
+        f"Expected 'greeting' and 'shout' symbols, got {names}"
+
+    # Hover over 'greeting' in the <script> part.  In the v3
+    # architecture this type information can only come out of
+    # tsserver with a working '@vue/typescript-plugin'.
+    log(client.name, "Requesting hover over 'greeting'...")
+    req_id = await client.request(
+        'textDocument/hover',
+        {
+            'textDocument': {'uri': file_uri},
+            'position': {'line': 1, 'character': 8},
+        },
+    )
+    response = await pump_until_response(client, req_id)
+    contents = json.dumps(response.get('result') or {})
+    log(client.name, f"Got hover: {contents}")
+    assert 'string' in contents, \
+        f"Expected hover mentioning 'string', got {contents}"
+
+    log(client.name, "OK! vue-language-server v3 is alive and typed!")
+
+    await client.byebye()
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/test/vuetail/fixture/.gitignore
+++ b/test/vuetail/fixture/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/test/vuetail/fixture/package.json
+++ b/test/vuetail/fixture/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "vuetail-fixture",
+  "private": true,
+  "devDependencies": {
+    "@tailwindcss/language-server": "^0.14.0",
+    "@vue/language-server": "^3.0.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.8.0",
+    "typescript-language-server": "^5.0.0",
+    "vue": "^3.5.0"
+  }
+}

--- a/test/vuetail/fixture/package.json
+++ b/test/vuetail/fixture/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "devDependencies": {
     "@tailwindcss/language-server": "^0.14.0",
-    "@vue/language-server": "^3.0.0",
+    "@vue/language-server": "^3.3.7",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.8.0",
     "typescript-language-server": "^5.0.0",

--- a/test/vuetail/fixture/src/App.vue
+++ b/test/vuetail/fixture/src/App.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+const greeting: string = 'Hello from Vue'
+
+function shout(s: string): string {
+  return s.toUpperCase()
+}
+</script>
+
+<template>
+  <div class="p-4">
+    <h1>{{ shout(greeting) }}</h1>
+  </div>
+</template>

--- a/test/vuetail/fixture/tailwind.config.js
+++ b/test/vuetail/fixture/tailwind.config.js
@@ -1,0 +1,6 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./src/**/*.vue'],
+  theme: {},
+  plugins: [],
+}

--- a/test/vuetail/fixture/tsconfig.json
+++ b/test/vuetail/fixture/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue"]
+}

--- a/test/vuetail/run.sh
+++ b/test/vuetail/run.sh
@@ -2,6 +2,13 @@
 set -e
 cd $(dirname "$0")
 
+# rass spawns the servers directly (no shell), which can't run the
+# .cmd shims npm creates on Windows
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || -n "$WINDIR" ]]; then
+    echo "Windows, skipping test" >&2
+    exit 77
+fi
+
 # Needed to npm-install the fixture and by the servers themselves
 if ! command -v npm >/dev/null 2>&1; then
     echo "npm not found, skipping test" >&2

--- a/test/vuetail/run.sh
+++ b/test/vuetail/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+cd $(dirname "$0")
+
+# Needed to npm-install the fixture and by the servers themselves
+if ! command -v npm >/dev/null 2>&1; then
+    echo "npm not found, skipping test" >&2
+    exit 77
+fi
+
+# Install fixture dependencies: vue-language-server v3,
+# typescript-language-server, tailwindcss-language-server, etc.
+(cd fixture && npm install --silent >/dev/null 2>&1) || {
+    echo "npm install failed in fixture, skipping test" >&2
+    exit 77
+}
+
+# Use the fixture-pinned servers regardless of what's in PATH
+export PATH="$PWD/fixture/node_modules/.bin:$PATH"
+
+../yoyo.sh ./client.py --rass-- vuetail


### PR DESCRIPTION
## What

Runs the test suite on a 3-OS (Linux, macOS, Windows) x 2-Python (3.10,
3.13) matrix instead of just ubuntu/3.10, plus a `workflow_dispatch`
trigger and a 30-minute job cap.

Making that actually work required a few portability fixes to the test
harness itself:

* `run-all.sh` gets a perl-based `timeout` fallback — macOS has no
  `timeout` command and GitHub's macOS runners don't even have
  coreutils' `gtimeout`.  The fallback kills the timed-out test's
  whole process group, otherwise lingering pipeline processes keep the
  captured-output pipe open and the suite hangs.
* CI runs with `BATCH_SIZE=4`: the timing-sensitive tests get flaky
  when 8 of them compete for the runners' 2 cores.
* Windows is `continue-on-error` (informational) for now: 14 tests
  pass there, but the timing-sensitive `drop-tardy-notification` is
  flaky on Windows runners — likely the known-fragile Windows stdio
  machinery (see the comment in `test2.py`), and worth fixing
  separately.

## Validation

Exercised on my fork until green
([run](https://github.com/pbgc/rassumfrassum/actions/runs/27440885653)):
Linux and macOS jobs pass 17/17 with 0 timeouts on both Pythons;
Windows passes 14 with the one known flake.

## Note

Stacked on #50 — the macOS jobs need that PR's stdio fix (and its
vuetail test is part of the 17).  Only the last three commits are new
here; this can be rebased once #50 lands, or just reviewed/merged
together with it.

As with #50: written with LLM assistance (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
